### PR TITLE
Fix various aspects of the Base64 parsing feature

### DIFF
--- a/layers/vulkansc/state_tracker/sc_pipeline_state.cpp
+++ b/layers/vulkansc/state_tracker/sc_pipeline_state.cpp
@@ -97,9 +97,9 @@ PipelineCache::Entry::JsonData PipelineCache::Entry::ParseJsonData(const Pipelin
             auto map_entries_json = spec_info["pMapEntries"];
             auto data_json = spec_info["pData"];
             for (uint32_t i = 0; i < result->mapEntryCount; ++i) {
-                map_entries[i].constantID = map_entries_json["constantID"].asUInt();
-                map_entries[i].offset = map_entries_json["offset"].asUInt();
-                map_entries[i].size = map_entries_json["size"].asUInt();
+                map_entries[i].constantID = map_entries_json[i]["constantID"].asUInt();
+                map_entries[i].offset = map_entries_json[i]["offset"].asUInt();
+                map_entries[i].size = map_entries_json[i]["size"].asUInt();
             }
             result->pMapEntries = map_entries;
             result->dataSize = spec_info["dataSize"].asUInt();

--- a/layers/vulkansc/state_tracker/sc_state_tracker.cpp
+++ b/layers/vulkansc/state_tracker/sc_state_tracker.cpp
@@ -284,6 +284,7 @@ void SCValidationStateTracker<BASE>::PostCallRecordCreateGraphicsPipelines(
                                                chassis::CreateGraphicsPipelines& chassis_state) {
     BASE::PostCallRecordCreateGraphicsPipelines(device, pipelineCache, count, pCreateInfos, pAllocator, pPipelines, record_obj,
                                                 pipeline_states, chassis_state);
+    if (VK_SUCCESS != record_obj.result) return;
 
     ReservePipelinePoolEntries(count, pCreateInfos);
 
@@ -304,6 +305,7 @@ void SCValidationStateTracker<BASE>::PostCallRecordCreateComputePipelines(
                                                chassis::CreateComputePipelines& chassis_state) {
     BASE::PostCallRecordCreateComputePipelines(device, pipelineCache, count, pCreateInfos, pAllocator, pPipelines, record_obj,
                                                pipeline_states, chassis_state);
+    if (VK_SUCCESS != record_obj.result) return;
 
     ReservePipelinePoolEntries(count, pCreateInfos);
 

--- a/tests/vulkansc/framework/vksc_pipeline_templates.h
+++ b/tests/vulkansc/framework/vksc_pipeline_templates.h
@@ -213,11 +213,13 @@
                     "pName": "main",
                     "pSpecializationInfo": {
                         "mapEntryCount": 1,
-                        "pMapEntries": {
-                            "constantID": 0,
-                            "offset": 0,
-                            "size": 4
-                        },
+                        "pMapEntries": [
+                            {
+                                "constantID": 0,
+                                "offset": 0,
+                                "size": 4
+                            }
+                        ],
                         "dataSize": 4,
                         "pData": [ 0, 0, 0, 0 ]
                     }
@@ -258,11 +260,13 @@
                     "pName": "main",
                     "pSpecializationInfo": {
                         "mapEntryCount": 1,
-                        "pMapEntries": {
-                            "constantID": 0,
-                            "offset": 0,
-                            "size": 4
-                        },
+                        "pMapEntries": [
+                            {
+                                "constantID": 0,
+                                "offset": 0,
+                                "size": 4
+                            }
+                        ],
                         "dataSize": 4,
                         "pData": "AAAAAA=="
                     }


### PR DESCRIPTION
This PR adds the following additions to the working branch of Base64 spec info parsing:

- Don't call post-record operations when pipeline creation otherwise failed
- Parse pMapEntries as a JSON array, as it should be
- Alter test data to reflect pMapEntries being arrays