### PR TITLE
layers: Fix swapchain related object counting issue

### DIFF
--- a/layers/vulkansc/base64.h
+++ b/layers/vulkansc/base64.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 RasterGrid Kft.
+ * Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 RasterGrid Kft.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/layers/vulkansc/core_checks/sc_core_validation.cpp
+++ b/layers/vulkansc/core_checks/sc_core_validation.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -631,7 +631,7 @@ bool SCCoreChecks::PreCallValidateCreateCommandPool(VkDevice device, const VkCom
     bool skip = BASE::PreCallValidateCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateCommandPool-device-05068", "command pools",
-                                       Count<vvl::CommandPool>(), "commandPoolRequestCount",
+                                       sc_reserved_objects_.command_pools.load(), "commandPoolRequestCount",
                                        sc_object_limits_.commandPoolRequestCount, 1);
 
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -679,8 +679,8 @@ bool SCCoreChecks::PreCallValidateCreateDescriptorSetLayout(VkDevice device, con
     bool skip = BASE::PreCallValidateCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateDescriptorSetLayout-device-05068",
-                                       "descriptor set layouts", Count<vvl::DescriptorSetLayout>(), "descriptorSetLayout",
-                                       sc_object_limits_.descriptorSetLayoutRequestCount, 1);
+                                       "descriptor set layouts", sc_reserved_objects_.descriptor_set_layouts.load(),
+                                       "descriptorSetLayout", sc_object_limits_.descriptorSetLayoutRequestCount, 1);
 
     if (pCreateInfo) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -732,9 +732,9 @@ bool SCCoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const Vk
                                                        const ErrorObject& error_obj) const {
     bool skip = BASE::PreCallValidateCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, error_obj);
 
-    skip |=
-        ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreatePipelineLayout-device-05068", "pipeline layouts",
-                                   Count<vvl::PipelineLayout>(), "pipelineLayout", sc_object_limits_.pipelineLayoutRequestCount, 1);
+    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreatePipelineLayout-device-05068", "pipeline layouts",
+                                       sc_reserved_objects_.pipeline_layouts.load(), "pipelineLayout",
+                                       sc_object_limits_.pipelineLayoutRequestCount, 1);
 
     return skip;
 }
@@ -744,9 +744,9 @@ bool SCCoreChecks::PreCallValidateCreateDescriptorPool(VkDevice device, const Vk
                                                        const ErrorObject& error_obj) const {
     bool skip = BASE::PreCallValidateCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, error_obj);
 
-    skip |=
-        ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateDescriptorPool-device-05068", "descriptor pool",
-                                   Count<vvl::DescriptorPool>(), "descriptorPool", sc_object_limits_.descriptorPoolRequestCount, 1);
+    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateDescriptorPool-device-05068", "descriptor pool",
+                                       sc_reserved_objects_.descriptor_pools.load(), "descriptorPool",
+                                       sc_object_limits_.descriptorPoolRequestCount, 1);
 
     return skip;
 }
@@ -778,7 +778,7 @@ bool SCCoreChecks::PreCallValidateAllocateDescriptorSets(VkDevice device, const 
 
     if (pAllocateInfo) {
         skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkAllocateDescriptorSets-device-05068",
-                                           "descriptor sets", Count<vvl::DescriptorSet>(), "descriptorSet",
+                                           "descriptor sets", sc_reserved_objects_.descriptor_sets.load(), "descriptorSet",
                                            sc_object_limits_.descriptorSetRequestCount, "pAllocateInfo->descriptorSetCount",
                                            pAllocateInfo->descriptorSetCount);
     }
@@ -792,7 +792,8 @@ bool SCCoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemory
     bool skip = BASE::PreCallValidateAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkAllocateMemory-device-05068", "device memory objects",
-                                       Count<vvl::DeviceMemory>(), "deviceMemory", sc_object_limits_.deviceMemoryRequestCount, 1);
+                                       sc_reserved_objects_.device_memories.load(), "deviceMemory",
+                                       sc_object_limits_.deviceMemoryRequestCount, 1);
 
     return skip;
 }
@@ -883,9 +884,9 @@ bool SCCoreChecks::PreCallValidateCreatePipelineCache(VkDevice device, const VkP
                                                       const ErrorObject& error_obj) const {
     bool skip = BASE::PreCallValidateCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, error_obj);
 
-    skip |=
-        ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreatePipelineCache-device-05068", "pipeline caches",
-                                   Count<vvl::PipelineCache>(), "pipelineCache", sc_object_limits_.pipelineCacheRequestCount, 1);
+    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreatePipelineCache-device-05068", "pipeline caches",
+                                       sc_reserved_objects_.pipeline_caches.load(), "pipelineCache",
+                                       sc_object_limits_.pipelineCacheRequestCount, 1);
 
     if (pCreateInfo) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -921,7 +922,8 @@ bool SCCoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQuery
     bool skip = BASE::PreCallValidateCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateQueryPool-device-05068", "query pools",
-                                       Count<vvl::QueryPool>(), "queryPool", sc_object_limits_.queryPoolRequestCount, 1);
+                                       sc_reserved_objects_.query_pools.load(), "queryPool",
+                                       sc_object_limits_.queryPoolRequestCount, 1);
 
     if (pCreateInfo) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -972,7 +974,8 @@ bool SCCoreChecks::PreCallValidateCreateRenderPass(VkDevice device, const VkRend
     bool skip = BASE::PreCallValidateCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateRenderPass-device-05068", "render passes",
-                                       Count<vvl::RenderPass>(), "renderPass", sc_object_limits_.renderPassRequestCount, 1);
+                                       sc_reserved_objects_.render_passes.load(), "renderPass",
+                                       sc_object_limits_.renderPassRequestCount, 1);
 
     if (pCreateInfo) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -1033,7 +1036,8 @@ bool SCCoreChecks::PreCallValidateCreateRenderPass2(VkDevice device, const VkRen
     bool skip = BASE::PreCallValidateCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateRenderPass2-device-05068", "render passes",
-                                       Count<vvl::RenderPass>(), "renderPass", sc_object_limits_.renderPassRequestCount, 1);
+                                       sc_reserved_objects_.render_passes.load(), "renderPass",
+                                       sc_object_limits_.renderPassRequestCount, 1);
 
     if (pCreateInfo) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -1094,7 +1098,8 @@ bool SCCoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFra
     bool skip = BASE::PreCallValidateCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateFramebuffer-device-05068", "framebuffers",
-                                       Count<vvl::Framebuffer>(), "framebuffer", sc_object_limits_.framebufferRequestCount, 1);
+                                       sc_reserved_objects_.framebuffers.load(), "framebuffer",
+                                       sc_object_limits_.framebufferRequestCount, 1);
 
     if (pCreateInfo) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -1116,7 +1121,7 @@ bool SCCoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCr
     bool skip = BASE::PreCallValidateCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateBuffer-device-05068", "buffers",
-                                       Count<vvl::Buffer>(), "buffer", sc_object_limits_.bufferRequestCount, 1);
+                                       sc_reserved_objects_.buffers.load(), "buffer", sc_object_limits_.bufferRequestCount, 1);
 
     if (pCreateInfo) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -1140,7 +1145,8 @@ bool SCCoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuff
     bool skip = BASE::PreCallValidateCreateBufferView(device, pCreateInfo, pAllocator, pView, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateBufferView-device-05068", "buffer views",
-                                       Count<vvl::BufferView>(), "bufferView", sc_object_limits_.bufferViewRequestCount, 1);
+                                       sc_reserved_objects_.buffer_views.load(), "bufferView",
+                                       sc_object_limits_.bufferViewRequestCount, 1);
 
     return skip;
 }
@@ -1150,8 +1156,8 @@ bool SCCoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCrea
                                               const ErrorObject& error_obj) const {
     bool skip = BASE::PreCallValidateCreateImage(device, pCreateInfo, pAllocator, pImage, error_obj);
 
-    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateImage-device-05068", "images", Count<vvl::Image>(),
-                                       "image", sc_object_limits_.imageRequestCount, 1);
+    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateImage-device-05068", "images",
+                                       sc_reserved_objects_.images.load(), "image", sc_object_limits_.imageRequestCount, 1);
 
     if (pCreateInfo) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -1179,7 +1185,8 @@ bool SCCoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImage
     }
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateImageView-device-05068", "image views",
-                                       Count<vvl::ImageView>(), "imageView", sc_object_limits_.imageViewRequestCount, 1);
+                                       sc_reserved_objects_.image_views.load(), "imageView",
+                                       sc_object_limits_.imageViewRequestCount, 1);
 
     if (pCreateInfo) {
         const auto normalized_subresource_range = image_state->NormalizeSubresourceRange(pCreateInfo->subresourceRange);
@@ -1235,7 +1242,7 @@ bool SCCoreChecks::PreCallValidateCreateSampler(VkDevice device, const VkSampler
     bool skip = BASE::PreCallValidateCreateSampler(device, pCreateInfo, pAllocator, pSampler, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateSampler-device-05068", "samplers",
-                                       Count<vvl::Sampler>(), "sampler", sc_object_limits_.samplerRequestCount, 1);
+                                       sc_reserved_objects_.samplers.load(), "sampler", sc_object_limits_.samplerRequestCount, 1);
 
     return skip;
 }
@@ -1248,8 +1255,8 @@ bool SCCoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device,
     bool skip = BASE::PreCallValidateCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, error_obj);
 
     skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateSamplerYcbcrConversion-device-05068",
-                                       "sampler conversions", Count<vvl::SamplerYcbcrConversion>(), "samplerYcbcrConversion",
-                                       sc_object_limits_.samplerYcbcrConversionRequestCount, 1);
+                                       "sampler conversions", sc_reserved_objects_.sampler_ycbcr_conversions.load(),
+                                       "samplerYcbcrConversion", sc_object_limits_.samplerYcbcrConversionRequestCount, 1);
 
     return skip;
 }
@@ -1259,8 +1266,8 @@ bool SCCoreChecks::PreCallValidateCreateFence(VkDevice device, const VkFenceCrea
                                               const ErrorObject& error_obj) const {
     bool skip = BASE::PreCallValidateCreateFence(device, pCreateInfo, pAllocator, pFence, error_obj);
 
-    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateFence-device-05068", "fences", Count<vvl::Fence>(),
-                                       "fence", sc_object_limits_.fenceRequestCount, 1);
+    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateFence-device-05068", "fences",
+                                       sc_reserved_objects_.fences.load(), "fence", sc_object_limits_.fenceRequestCount, 1);
 
     return skip;
 }
@@ -1270,8 +1277,9 @@ bool SCCoreChecks::PreCallValidateCreateSemaphore(VkDevice device, const VkSemap
                                                   const ErrorObject& error_obj) const {
     bool skip = BASE::PreCallValidateCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, error_obj);
 
-    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateSemaphore-device-05068", "semaphores",
-                                       Count<vvl::Semaphore>(), "semaphore", sc_object_limits_.semaphoreRequestCount, 1);
+    skip |=
+        ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateSemaphore-device-05068", "semaphores",
+                                   sc_reserved_objects_.semaphores.load(), "semaphore", sc_object_limits_.semaphoreRequestCount, 1);
 
     return skip;
 }
@@ -1281,8 +1289,8 @@ bool SCCoreChecks::PreCallValidateCreateEvent(VkDevice device, const VkEventCrea
                                               const ErrorObject& error_obj) const {
     bool skip = BASE::PreCallValidateCreateEvent(device, pCreateInfo, pAllocator, pEvent, error_obj);
 
-    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateEvent-device-05068", "events", Count<vvl::Event>(),
-                                       "event", sc_object_limits_.eventRequestCount, 1);
+    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateEvent-device-05068", "events",
+                                       sc_reserved_objects_.events.load(), "event", sc_object_limits_.eventRequestCount, 1);
 
     return skip;
 }
@@ -1292,8 +1300,9 @@ bool SCCoreChecks::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSw
                                                      const ErrorObject& error_obj) const {
     bool skip = BASE::PreCallValidateCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, error_obj);
 
-    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateSwapchainKHR-device-05068", "swapchains",
-                                       Count<vvl::Swapchain>(), "swapchain", sc_object_limits_.swapchainRequestCount, 1);
+    skip |=
+        ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateSwapchainKHR-device-05068", "swapchains",
+                                   sc_reserved_objects_.swapchains.load(), "swapchain", sc_object_limits_.swapchainRequestCount, 1);
 
     skip |= ValidateSwapchainCreateInfo(device, *pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
 
@@ -1307,8 +1316,8 @@ bool SCCoreChecks::PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uin
     bool skip =
         BASE::PreCallValidateCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, error_obj);
 
-    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateSharedSwapchainsKHR-device-05068",
-                                       "swapchains", Count<vvl::Swapchain>(), "swapchain", sc_object_limits_.swapchainRequestCount,
+    skip |= ValidateObjectRequestCount(device, error_obj.location, "VUID-vkCreateSharedSwapchainsKHR-device-05068", "swapchains",
+                                       sc_reserved_objects_.swapchains.load(), "swapchain", sc_object_limits_.swapchainRequestCount,
                                        "swapchainCount", swapchainCount);
 
     for (uint32_t i = 0; i < swapchainCount; i++) {

--- a/layers/vulkansc/core_checks/sc_core_validation.h
+++ b/layers/vulkansc/core_checks/sc_core_validation.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkansc/core_checks/sc_spirv_validation.cpp
+++ b/layers/vulkansc/core_checks/sc_spirv_validation.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkansc/sc_vuid_enums.h
+++ b/layers/vulkansc/sc_vuid_enums.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkansc/state_tracker/sc_descriptor_sets.h
+++ b/layers/vulkansc/state_tracker/sc_descriptor_sets.h
@@ -16,25 +16,18 @@
  * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #pragma once
-#include "state_tracker/cmd_buffer_state.h"
+#include "state_tracker/descriptor_sets.h"
 
 #include <atomic>
 
 namespace vvl::sc {
 
-class CommandPool : public vvl::CommandPool {
+class DescriptorPool : public vvl::DescriptorPool {
   public:
-    uint32_t max_command_buffers;
-    std::atomic_uint32_t command_buffers_recording;
+    std::atomic_uint32_t allocated_descriptor_sets{0};
 
-    CommandPool(ValidationStateTracker &dev, VkCommandPool cp, const VkCommandPoolCreateInfo *pCreateInfo, VkQueueFlags flags)
-        : vvl::CommandPool(dev, cp, pCreateInfo, flags), max_command_buffers(0), command_buffers_recording(0) {
-        const auto *mem_reservation_info =
-            vku::FindStructInPNextChain<VkCommandPoolMemoryReservationCreateInfo>(pCreateInfo->pNext);
-        if (mem_reservation_info) {
-            max_command_buffers = mem_reservation_info->commandPoolMaxCommandBuffers;
-        }
-    }
+    DescriptorPool(ValidationStateTracker &dev, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo *pCreateInfo)
+        : vvl::DescriptorPool(dev, handle, pCreateInfo) {}
 };
 
 }  // namespace vvl::sc

--- a/layers/vulkansc/state_tracker/sc_device_state.h
+++ b/layers/vulkansc/state_tracker/sc_device_state.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkansc/state_tracker/sc_pipeline_state.cpp
+++ b/layers/vulkansc/state_tracker/sc_pipeline_state.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkansc/state_tracker/sc_pipeline_state.h
+++ b/layers/vulkansc/state_tracker/sc_pipeline_state.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkansc/state_tracker/sc_state_tracker.h
+++ b/layers/vulkansc/state_tracker/sc_state_tracker.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include "vulkansc/state_tracker/sc_device_state.h"
 #include "vulkansc/state_tracker/sc_pipeline_state.h"
 #include "vulkansc/state_tracker/sc_cmd_buffer_state.h"
+#include "vulkansc/state_tracker/sc_descriptor_sets.h"
 #include "generated/layer_chassis_dispatch.h"
 #include "error_message/logging.h"
 #include "vulkan/vk_layer.h"
@@ -31,6 +32,7 @@
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkPipelineCache, vvl::sc::PipelineCache, vvl::PipelineCache);
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkPipeline, vvl::sc::Pipeline, vvl::Pipeline);
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandPool, vvl::sc::CommandPool, vvl::CommandPool);
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkDescriptorPool, vvl::sc::DescriptorPool, vvl::DescriptorPool);
 
 template <typename BASE>
 class SCValidationStateTracker : public BASE {
@@ -78,9 +80,16 @@ class SCValidationStateTracker : public BASE {
     void PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool,
                                          const RecordObject& record_obj) override;
+    void PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
+                                      const RecordObject& record_obj) override;
     std::shared_ptr<vvl::PipelineCache> CreatePipelineCacheState(VkPipelineCache pipeline_cache,
                                                                  const VkPipelineCacheCreateInfo* pCreateInfo) const override;
-
+    void PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
+                                           const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
+                                           const RecordObject& record_obj) override;
+    void PreCallRecordDestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache, const VkAllocationCallbacks* pAllocator,
+                                           const RecordObject& record_obj) override;
     std::shared_ptr<vvl::Pipeline> CreateGraphicsPipelineState(
         const VkGraphicsPipelineCreateInfo* create_info, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
         std::shared_ptr<const vvl::RenderPass>&& render_pass, std::shared_ptr<const vvl::PipelineLayout>&& layout,
@@ -101,16 +110,58 @@ class SCValidationStateTracker : public BASE {
                                               chassis::CreateComputePipelines& chassis_state) override;
     void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator,
                                       const RecordObject& record_obj) override;
+    void PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                    VkBuffer* pBuffer, const RecordObject& record_obj) override;
+    void PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
+                                    const RecordObject& record_obj) override;
+    void PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
+                                        const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
+                                        const RecordObject& record_obj) override;
+    void PreCallRecordDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks* pAllocator,
+                                        const RecordObject& record_obj) override;
+    void PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                   VkImage* pImage, const RecordObject& record_obj) override;
+    void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
+                                   const RecordObject& record_obj) override;
     void PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkImageView* pView,
                                        const RecordObject& record_obj) override;
     void PreCallRecordDestroyImageView(VkDevice device, VkImageView imageView, const VkAllocationCallbacks* pAllocator,
                                        const RecordObject& record_obj) override;
+    void PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                     const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
+                                     const RecordObject& record_obj) override;
+    void PreCallRecordDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks* pAllocator,
+                                     const RecordObject& record_obj) override;
+    void PostCallRecordCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                    const VkAllocationCallbacks* pAllocator,
+                                                    VkSamplerYcbcrConversion* pYcbcrConversion,
+                                                    const RecordObject& record_obj) override;
+    void PostCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
+                                                     const VkAllocationCallbacks* pAllocator,
+                                                     const RecordObject& record_obj) override;
+    void PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
+                                            const RecordObject& record_obj) override;
+    void PreCallRecordDestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout,
+                                            const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) override;
     void PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                                  const VkAllocationCallbacks* pAllocator, VkDescriptorSetLayout* pSetLayout,
                                                  const RecordObject& record_obj) override;
     void PreCallRecordDestroyDescriptorSetLayout(VkDevice device, VkDescriptorSetLayout descriptorSetLayout,
                                                  const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) override;
+    std::shared_ptr<vvl::DescriptorPool> CreateDescriptorPoolState(VkDescriptorPool handle,
+                                                                   const VkDescriptorPoolCreateInfo* create_info) override;
+    void PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
+                                            const RecordObject& record_obj) override;
+    void PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags,
+                                           const RecordObject& record_obj) override;
+    void PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                              VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj,
+                                              vvl::AllocateDescriptorSetsData& ads_state) override;
+    void PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
+                                         const VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj) override;
     void PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                         const RecordObject& record_obj) override;
@@ -119,11 +170,39 @@ class SCValidationStateTracker : public BASE {
                                          const RecordObject& record_obj) override;
     void PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator,
                                         const RecordObject& record_obj) override;
+    void PostCallRecordCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+                                         const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
+                                         const RecordObject& record_obj) override;
+    void PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator,
+                                         const RecordObject& record_obj) override;
+    void PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                   VkFence* pFence, const RecordObject& record_obj) override;
+    void PreCallRecordDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks* pAllocator,
+                                   const RecordObject& record_obj) override;
+    void PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
+                                       const RecordObject& record_obj) override;
+    void PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator,
+                                       const RecordObject& record_obj) override;
+    void PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                   VkEvent* pEvent, const RecordObject& record_obj) override;
+    void PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator,
+                                   const RecordObject& record_obj) override;
+    void PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool,
+                                       const RecordObject& record_obj) override;
     void PostCallRecordCreatePrivateDataSlotEXT(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkPrivateDataSlot* pPrivateDataSlot,
                                                 const RecordObject& record_obj) override;
     void PreCallRecordDestroyPrivateDataSlotEXT(VkDevice device, VkPrivateDataSlot privateDataSlot,
                                                 const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) override;
+    void PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
+                                                 const VkSwapchainCreateInfoKHR* pCreateInfos,
+                                                 const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains,
+                                                 const RecordObject& record_obj) override;
+    void PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                          const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain,
+                                          const RecordObject& record_obj) override;
     void PostCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
                                           const RecordObject& record_obj) override;
     void PreCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, const RecordObject& record_obj) override;
@@ -146,10 +225,30 @@ class SCValidationStateTracker : public BASE {
 
     // Object / sub-object count tracking
     struct {
+        std::atomic_uint32_t semaphores{0};
         std::atomic_uint32_t command_buffers{0};
+        std::atomic_uint32_t fences{0};
+        std::atomic_uint32_t device_memories{0};
+        std::atomic_uint32_t buffers{0};
+        std::atomic_uint32_t images{0};
+        std::atomic_uint32_t events{0};
+        std::atomic_uint32_t query_pools{0};
+        std::atomic_uint32_t buffer_views{0};
+        std::atomic_uint32_t image_views{0};
+        std::atomic_uint32_t layered_image_views{0};
+        std::atomic_uint32_t pipeline_caches{0};
+        std::atomic_uint32_t pipeline_layouts{0};
+        std::atomic_uint32_t render_passes{0};
         std::atomic_uint32_t graphics_pipelines{0};
         std::atomic_uint32_t compute_pipelines{0};
-        std::atomic_uint32_t layered_image_views{0};
+        std::atomic_uint32_t descriptor_set_layouts{0};
+        std::atomic_uint32_t samplers{0};
+        std::atomic_uint32_t descriptor_pools{0};
+        std::atomic_uint32_t descriptor_sets{0};
+        std::atomic_uint32_t framebuffers{0};
+        std::atomic_uint32_t command_pools{0};
+        std::atomic_uint32_t sampler_ycbcr_conversions{0};
+        std::atomic_uint32_t swapchains{0};
         std::atomic_uint32_t subpass_descriptions{0};
         std::atomic_uint32_t attachment_descriptions{0};
         std::atomic_uint32_t descriptor_set_layout_bindings{0};

--- a/layers/vulkansc/sync/sc_sync_validation.cpp
+++ b/layers/vulkansc/sync/sc_sync_validation.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkansc/sync/sc_sync_validation.h
+++ b/layers/vulkansc/sync/sc_sync_validation.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/tests_vksc.py
+++ b/scripts/tests_vksc.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023-2024 The Khronos Group Inc.
+# Copyright (c) 2023-2025 The Khronos Group Inc.
 # Copyright (c) 2020-2024 Valve Corporation
 # Copyright (c) 2020-2024 LunarG, Inc.
-# Copyright (c) 2023-2024 RasterGrid Kft.
+# Copyright (c) 2023-2025 RasterGrid Kft.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/vksc_convert_tests.py
+++ b/scripts/vksc_convert_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
-# Copyright (c) 2023-2024 The Khronos Group Inc.
-# Copyright (c) 2023-2024 RasterGrid Kft.
+# Copyright (c) 2023-2025 The Khronos Group Inc.
+# Copyright (c) 2023-2025 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/icd/VVL_Test_ICD_vksc.def
+++ b/tests/icd/VVL_Test_ICD_vksc.def
@@ -1,7 +1,7 @@
 ;;;; Begin Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
 ; Copyright (c) 2024 Valve Corporation
-; Copyright (c) 2024 RasterGrid Kft.
+; Copyright (c) 2024-2025 RasterGrid Kft.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.

--- a/tests/vulkansc/CMakeLists.txt
+++ b/tests/vulkansc/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ~~~
-# Copyright (c) 2023-2024 RasterGrid Kft.
+# Copyright (c) 2023-2025 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/custom_test_framework.h
+++ b/tests/vulkansc/framework/custom_test_framework.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_layer_validation_tests.cpp
+++ b/tests/vulkansc/framework/vksc_layer_validation_tests.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_layer_validation_tests.h
+++ b/tests/vulkansc/framework/vksc_layer_validation_tests.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_pipeline_templates.h
+++ b/tests/vulkansc/framework/vksc_pipeline_templates.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2024 The Khronos Group Inc.
- * Copyright (c) 2024-2024 RasterGrid Kft.
+ * Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_render_framework.cpp
+++ b/tests/vulkansc/framework/vksc_render_framework.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_render_framework.h
+++ b/tests/vulkansc/framework/vksc_render_framework.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_shader_templates.h
+++ b/tests/vulkansc/framework/vksc_shader_templates.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2024 The Khronos Group Inc.
- * Copyright (c) 2024-2024 RasterGrid Kft.
+ * Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_test_dispatch_helper.cpp
+++ b/tests/vulkansc/framework/vksc_test_dispatch_helper.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_test_dispatch_helper.h
+++ b/tests/vulkansc/framework/vksc_test_dispatch_helper.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_test_environment.cpp
+++ b/tests/vulkansc/framework/vksc_test_environment.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2024 The Khronos Group Inc.
  * Copyright (c) 2015-2024 Valve Corporation
  * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_test_environment.h
+++ b/tests/vulkansc/framework/vksc_test_environment.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2024 The Khronos Group Inc.
- * Copyright (c) 2024-2024 RasterGrid Kft.
+ * Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_test_pipeline_cache_helper.cpp
+++ b/tests/vulkansc/framework/vksc_test_pipeline_cache_helper.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_test_pipeline_cache_helper.h
+++ b/tests/vulkansc/framework/vksc_test_pipeline_cache_helper.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_test_pipeline_helper.cpp
+++ b/tests/vulkansc/framework/vksc_test_pipeline_helper.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/framework/vksc_test_pipeline_helper.h
+++ b/tests/vulkansc/framework/vksc_test_pipeline_helper.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2024 The Khronos Group Inc.
- * Copyright (c) 2024-2024 RasterGrid Kft.
+ * Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/command.cpp
+++ b/tests/vulkansc/negative/command.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/device_create.cpp
+++ b/tests/vulkansc/negative/device_create.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/implicit.cpp
+++ b/tests/vulkansc/negative/implicit.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/object_reservation.cpp
+++ b/tests/vulkansc/negative/object_reservation.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/others.cpp
+++ b/tests/vulkansc/negative/others.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/pipeline.cpp
+++ b/tests/vulkansc/negative/pipeline.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/pipeline_cache_data.cpp
+++ b/tests/vulkansc/negative/pipeline_cache_data.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/ported.cpp
+++ b/tests/vulkansc/negative/ported.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/render_pass.cpp
+++ b/tests/vulkansc/negative/render_pass.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/shader_spirv.cpp
+++ b/tests/vulkansc/negative/shader_spirv.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/negative/wsi.cpp
+++ b/tests/vulkansc/negative/wsi.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/positive/implicit.cpp
+++ b/tests/vulkansc/positive/implicit.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/positive/instance.cpp
+++ b/tests/vulkansc/positive/instance.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/positive/others.cpp
+++ b/tests/vulkansc/positive/others.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/positive/pipeline.cpp
+++ b/tests/vulkansc/positive/pipeline.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/positive/pipeline_cache_data.cpp
+++ b/tests/vulkansc/positive/pipeline_cache_data.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/vulkansc/positive/shader_spirv.cpp
+++ b/tests/vulkansc/positive/shader_spirv.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The validation layers create internal image and
memory objects for swapchains which makes the
object count VUs report false positives in the
presence of swapchains. This change fixes that
by explicitly counting every object.