### PR TITLE
layers: Validation for vkGetDescriptorSetLayoutSupport

### DIFF
--- a/layers/vulkansc/core_checks/sc_core_validation.cpp
+++ b/layers/vulkansc/core_checks/sc_core_validation.cpp
@@ -668,47 +668,13 @@ bool Device::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkD
                                    "descriptorSetLayout", sc_device_state->sc_object_limits_.descriptorSetLayoutRequestCount, 1);
 
     if (pCreateInfo) {
-        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-
-        if (pCreateInfo->bindingCount > sc_device_state->phys_dev_props_sc_10_.maxDescriptorSetLayoutBindings) {
-            skip |=
-                LogError("VUID-VkDescriptorSetLayoutCreateInfo-bindingCount-05011", device, create_info_loc.dot(Field::bindCount),
-                         "(%u) exceeds the device limit "
-                         "VkPhysicalDeviceVulkanSC10Properties::maxDescriptorSetLayoutBindings (%u).",
-                         pCreateInfo->bindingCount, sc_device_state->phys_dev_props_sc_10_.maxDescriptorSetLayoutBindings);
-        }
+        skip |= ValidateDescriptorSetLayoutCreateInfoSC(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
 
         skip |= ValidateCombinedRequestCount(
             device, error_obj.location, "VUID-vkCreateDescriptorSetLayout-layoutbindings-device-05089", "VkDescriptorSetLayout",
             "descriptor set layout bindings", sc_device_state->sc_reserved_objects_.descriptor_set_layout_bindings.load(),
             "descriptorSetLayoutBinding", sc_device_state->sc_object_limits_.descriptorSetLayoutBindingRequestCount,
             "pCreateInfo->bindingCount", pCreateInfo->bindingCount);
-
-        uint32_t requested_immutable_samplers = 0;
-        for (uint32_t i = 0; i < pCreateInfo->bindingCount; ++i) {
-            const auto& binding = pCreateInfo->pBindings[i];
-            if (binding.binding >= sc_device_state->sc_object_limits_.descriptorSetLayoutBindingLimit) {
-                skip |= LogError("VUID-VkDescriptorSetLayoutBinding-binding-05012", device,
-                                 create_info_loc.dot(Field::pBindings, i).dot(Field::binding),
-                                 "(%u) exceeds the limit requested in "
-                                 "VkDeviceObjectReservationCreateInfo::descriptorSetLayoutBindingLimit (%u).",
-                                 binding.binding, sc_device_state->sc_object_limits_.descriptorSetLayoutBindingLimit);
-            }
-
-            if ((binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER ||
-                 binding.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) &&
-                binding.pImmutableSamplers != nullptr) {
-                requested_immutable_samplers += binding.descriptorCount;
-            }
-        }
-
-        if (requested_immutable_samplers > sc_device_state->sc_object_limits_.maxImmutableSamplersPerDescriptorSetLayout) {
-            skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-descriptorCount-05071", device, error_obj.location,
-                             "the total immutable samplers (%u) across the specified bindings exceeds the limit requested "
-                             "in VkDeviceObjectReservationCreateInfo::maxImmutableSamplersPerDescriptorSetLayout (%u).",
-                             requested_immutable_samplers,
-                             sc_device_state->sc_object_limits_.maxImmutableSamplersPerDescriptorSetLayout);
-        }
     }
 
     return skip;
@@ -1451,6 +1417,54 @@ bool Device::PreCallValidateGetFaultData(VkDevice device, VkFaultQueryBehavior f
         skip |= LogError("VUID-vkGetFaultData-pFaultCount-05020", device, error_obj.location.dot(Field::pFaultCount),
                          "(%u) exceeds the device limit VkPhysicalDeviceVulkanSC10Properties::maxQueryFaultCount (%u).",
                          *pFaultCount, sc_device_state->phys_dev_props_sc_10_.maxQueryFaultCount);
+    }
+
+    return skip;
+}
+
+bool Device::PreCallValidateGetDescriptorSetLayoutSupport(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                          VkDescriptorSetLayoutSupport* pSupport,
+                                                          const ErrorObject& error_obj) const {
+    bool skip = BaseClass::PreCallValidateGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, error_obj);
+    skip |= ValidateDescriptorSetLayoutCreateInfoSC(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
+    return skip;
+}
+
+bool Device::ValidateDescriptorSetLayoutCreateInfoSC(const VkDescriptorSetLayoutCreateInfo& create_info,
+                                                     const Location& create_info_loc) const {
+    bool skip = false;
+
+    if (create_info.bindingCount > sc_device_state->phys_dev_props_sc_10_.maxDescriptorSetLayoutBindings) {
+        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-bindingCount-05011", device, create_info_loc.dot(Field::bindCount),
+                         "(%u) exceeds the device limit "
+                         "VkPhysicalDeviceVulkanSC10Properties::maxDescriptorSetLayoutBindings (%u).",
+                         create_info.bindingCount, sc_device_state->phys_dev_props_sc_10_.maxDescriptorSetLayoutBindings);
+    }
+
+    uint32_t requested_immutable_samplers = 0;
+    for (uint32_t i = 0; i < create_info.bindingCount; ++i) {
+        const auto& binding = create_info.pBindings[i];
+        if (binding.binding >= sc_device_state->sc_object_limits_.descriptorSetLayoutBindingLimit) {
+            skip |= LogError("VUID-VkDescriptorSetLayoutBinding-binding-05012", device,
+                             create_info_loc.dot(Field::pBindings, i).dot(Field::binding),
+                             "(%u) exceeds the limit requested in "
+                             "VkDeviceObjectReservationCreateInfo::descriptorSetLayoutBindingLimit (%u).",
+                             binding.binding, sc_device_state->sc_object_limits_.descriptorSetLayoutBindingLimit);
+        }
+
+        if ((binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER ||
+             binding.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) &&
+            binding.pImmutableSamplers != nullptr) {
+            requested_immutable_samplers += binding.descriptorCount;
+        }
+    }
+
+    if (requested_immutable_samplers > sc_device_state->sc_object_limits_.maxImmutableSamplersPerDescriptorSetLayout) {
+        skip |=
+            LogError("VUID-VkDescriptorSetLayoutCreateInfo-descriptorCount-05071", device, create_info_loc,
+                     "the total immutable samplers (%u) across the specified bindings exceeds the limit requested "
+                     "in VkDeviceObjectReservationCreateInfo::maxImmutableSamplersPerDescriptorSetLayout (%u).",
+                     requested_immutable_samplers, sc_device_state->sc_object_limits_.maxImmutableSamplersPerDescriptorSetLayout);
     }
 
     return skip;

--- a/layers/vulkansc/core_checks/sc_core_validation.h
+++ b/layers/vulkansc/core_checks/sc_core_validation.h
@@ -105,6 +105,9 @@ class Device : public vvl::sc::DeviceProxy<CoreChecks> {
 
     bool ValidateSwapchainCreateInfo(VkDevice device, const VkSwapchainCreateInfoKHR& create_info, const Location& loc) const;
 
+    bool ValidateDescriptorSetLayoutCreateInfoSC(const VkDescriptorSetLayoutCreateInfo& create_info,
+                                                 const Location& create_info_loc) const;
+
     // Functions removed in Vulkan SC
     bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
@@ -252,6 +255,9 @@ class Device : public vvl::sc::DeviceProxy<CoreChecks> {
                                            const ErrorObject& error_obj) const override;
     bool PreCallValidateGetFaultData(VkDevice device, VkFaultQueryBehavior faultQueryBehavior, VkBool32* pUnrecordedFaults,
                                      uint32_t* pFaultCount, VkFaultData* pFaults, const ErrorObject& error_obj) const override;
+    bool PreCallValidateGetDescriptorSetLayoutSupport(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                      VkDescriptorSetLayoutSupport* pSupport,
+                                                      const ErrorObject& error_obj) const override;
 
     // SPIR-V validation related utilities
     bool ValidatePipelineStageInfo(uint32_t stage_index, const VkPipelineShaderStageCreateInfo& stage_info,

--- a/tests/vulkansc/negative/others.cpp
+++ b/tests/vulkansc/negative/others.cpp
@@ -173,6 +173,45 @@ TEST_F(VkSCLayerTest, CreateDescriptorSetLayoutExceededBindingLimit) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(VkSCLayerTest, GetDescriptorSetLayoutSupportExceededBindingLimit) {
+    TEST_DESCRIPTION("vkGetDescriptorSetLayoutSupport - binding index cannot exceed descriptorSetLayoutBindingLimit");
+
+    auto sc_10_features = vku::InitStruct<VkPhysicalDeviceVulkanSC10Features>();
+    auto object_reservation_info1 = vksc::GetDefaultObjectReservationCreateInfo();
+    auto object_reservation_info2 = vksc::GetDefaultObjectReservationCreateInfo();
+    auto object_reservation_info3 = vksc::GetDefaultObjectReservationCreateInfo();
+
+    object_reservation_info1.pNext = &sc_10_features;
+    object_reservation_info2.pNext = &object_reservation_info1;
+    object_reservation_info3.pNext = &object_reservation_info2;
+
+    object_reservation_info1.descriptorSetLayoutBindingLimit = 1;
+    object_reservation_info2.descriptorSetLayoutBindingLimit = 4;
+    object_reservation_info3.descriptorSetLayoutBindingLimit = 3;
+
+    RETURN_IF_SKIP(InitFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &object_reservation_info3));
+
+    VkDescriptorSetLayoutBinding bindings[] = {
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+        {5, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+        {4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+        {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+    };
+
+    auto create_info = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    create_info.bindingCount = sizeof(bindings) / sizeof(bindings[0]);
+    create_info.pBindings = &bindings[0];
+
+    auto support = vku::InitStruct<VkDescriptorSetLayoutSupport>();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutBinding-binding-05012");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutBinding-binding-05012");
+    vksc::GetDescriptorSetLayoutSupport(m_device->handle(), &create_info, &support);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(VkSCLayerTest, CreateDescriptorSetLayoutExceededBindingCountLimit) {
     TEST_DESCRIPTION("vkCreateDescriptorSetLayout - binding count cannot exceed descriptorSetLayoutBindingLimit");
 
@@ -202,6 +241,38 @@ TEST_F(VkSCLayerTest, CreateDescriptorSetLayoutExceededBindingCountLimit) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutCreateInfo-bindingCount-05011");
     vksc::CreateDescriptorSetLayout(m_device->handle(), &create_info, nullptr, &layout);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkSCLayerTest, GetDescriptorSetLayoutSupportExceededBindingCountLimit) {
+    TEST_DESCRIPTION("vkGetDescriptorSetLayoutSupport - binding count cannot exceed descriptorSetLayoutBindingLimit");
+
+    RETURN_IF_SKIP(InitFramework());
+
+    const uint32_t limit = GetVulkanSC10Properties().maxDescriptorSetLayoutBindings;
+
+    auto sc_10_features = vku::InitStruct<VkPhysicalDeviceVulkanSC10Features>();
+    auto object_reservation_info = vksc::GetDefaultObjectReservationCreateInfo();
+
+    object_reservation_info.pNext = &sc_10_features;
+    object_reservation_info.descriptorSetLayoutBindingLimit = limit + 1;
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &object_reservation_info));
+
+    std::vector<VkDescriptorSetLayoutBinding> bindings;
+    for (uint32_t i = 0; i <= limit; ++i) {
+        VkDescriptorSetLayoutBinding binding = {i, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT};
+        bindings.push_back(binding);
+    }
+
+    auto create_info = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    create_info.bindingCount = static_cast<uint32_t>(bindings.size());
+    create_info.pBindings = bindings.data();
+
+    auto support = vku::InitStruct<VkDescriptorSetLayoutSupport>();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutCreateInfo-bindingCount-05011");
+    vksc::GetDescriptorSetLayoutSupport(m_device->handle(), &create_info, &support);
     m_errorMonitor->VerifyFound();
 }
 
@@ -260,6 +331,63 @@ TEST_F(VkSCLayerTest, CreateDescriptorSetLayoutExceededImmutableSamplerLimit) {
     // Should succeed if we exclude the last two bindings
     create_info.bindingCount--;
     vkt::DescriptorSetLayout set_layout(*m_device, create_info);
+}
+
+TEST_F(VkSCLayerTest, GetDescriptorSetLayoutSupportExceededImmutableSamplerLimit) {
+    TEST_DESCRIPTION("vkGetDescriptorSetLayoutSupport - immutable sampler limit cannot exceed descriptorSetLayoutBindingLimit");
+
+    auto sc_10_features = vku::InitStruct<VkPhysicalDeviceVulkanSC10Features>();
+    auto object_reservation_info1 = vksc::GetDefaultObjectReservationCreateInfo();
+    auto object_reservation_info2 = vksc::GetDefaultObjectReservationCreateInfo();
+    auto object_reservation_info3 = vksc::GetDefaultObjectReservationCreateInfo();
+
+    object_reservation_info1.pNext = &sc_10_features;
+    object_reservation_info2.pNext = &object_reservation_info1;
+    object_reservation_info3.pNext = &object_reservation_info2;
+
+    object_reservation_info1.maxImmutableSamplersPerDescriptorSetLayout = 0;
+    object_reservation_info2.maxImmutableSamplersPerDescriptorSetLayout = 7;
+    object_reservation_info3.maxImmutableSamplersPerDescriptorSetLayout = 5;
+
+    RETURN_IF_SKIP(InitFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &object_reservation_info3));
+
+    auto sampler_ci = vku::InitStruct<VkSamplerCreateInfo>();
+    vkt::Sampler sampler(*m_device, sampler_ci);
+
+    std::vector<VkSampler> samplers(10, sampler.handle());
+
+    VkDescriptorSetLayoutBinding bindings[] = {
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 4, VK_SHADER_STAGE_FRAGMENT_BIT, samplers.data()},
+        {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, samplers.data()},
+        {2, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, samplers.data()},
+        {3, VK_DESCRIPTOR_TYPE_SAMPLER, 3, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+        {4, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, samplers.data()},
+        // The bindings below will cause the limit to be exceeded
+        {5, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, samplers.data()},
+        {6, VK_DESCRIPTOR_TYPE_SAMPLER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, samplers.data()},
+    };
+
+    auto create_info = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    create_info.bindingCount = sizeof(bindings) / sizeof(bindings[0]);
+    create_info.pBindings = &bindings[0];
+
+    auto support = vku::InitStruct<VkDescriptorSetLayoutSupport>();
+
+    // Should fail with all bindings
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutCreateInfo-descriptorCount-05071");
+    vksc::GetDescriptorSetLayoutSupport(m_device->handle(), &create_info, &support);
+    m_errorMonitor->VerifyFound();
+
+    // Should still fail if we exclude the last binding
+    create_info.bindingCount--;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorSetLayoutCreateInfo-descriptorCount-05071");
+    vksc::GetDescriptorSetLayoutSupport(m_device->handle(), &create_info, &support);
+    m_errorMonitor->VerifyFound();
+
+    // Should succeed if we exclude the last two bindings
+    create_info.bindingCount--;
+    vksc::GetDescriptorSetLayoutSupport(m_device->handle(), &create_info, &support);
 }
 
 TEST_F(VkSCLayerTest, CreateQueryPoolExceededMaxQueriesPerPool) {


### PR DESCRIPTION
Apparently, some of the SC specific VUs for
VkDescriptorSetLayoutCreateInfo were not handled
in vkGetDescriptorSetLayoutSupport that also accepts this structure as input.